### PR TITLE
Add AWS `arm64` AMIs

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -12,7 +12,7 @@ RUNNER_VERSION:
 
 ARCH:
   - amd64
-  # - arm64
+  - arm64
 
 ENV:
   - aws


### PR DESCRIPTION
This PR enables `arm64` AMIs to be created in AWS.